### PR TITLE
feat: populate + virtuals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@selego/mongoose-elastic",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "src/index.js",
   "scripts": {
     "test": "jest --detectOpenHandles --forceExit"


### PR DESCRIPTION
## Issue

The ElasticSearch schema is related to the `schema.paths` of the Mongoose Model. So, any virtuals would not be added to the ES index.

## Solution

Add the possibility to declare a list of `populate` and a list of `virtuals` properties to the index.

### Exemple

Let's take this `Classe` model for example:

```javascript
const Schema = new mongoose.Schema({
  etablissementId: {
    type: String,
  },
});

Schema.virtual("etablissement", {
  ref: "etablissement",
  localField: "etablissementId",
  foreignField: "_id",
  justOne: true,
});

Schema.virtual("department").get(function () {
  return this.etablissement?.department ?? null;
});

Schema.virtual("region").get(function () {
  return this.etablissement?.region ?? null;
});
```

If we add a simple **@selego/mongoose-elastic** configuration

```javascript
Schema.plugin(mongooseElastic(esClient), "classe");
```

Only `etablissementId` will be present in the ES index.

In order to have `.department` & `.region` available in our model we need to `.populate(["etablissement"])`

**So this PR solves this by enabling these options like so:**

```javascript
Schema.plugin(
  mongooseElastic(esClient, {
    populate: ["etablissement"],
    virtuals: [
      { key: "region", type: "String" },
      { key: "department", type: "String" },
    ],
  }),
  "classe",
);
```